### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: build
 on: [pull_request, push]
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/Cypphi/mc-remote-control/security/code-scanning/1](https://github.com/Cypphi/mc-remote-control/security/code-scanning/1)

To properly address the problem, add a `permissions` block at the workflow root (top-level, before `jobs:`), specifying the minimal permissions necessary for the workflow’s steps. Since these steps (checking out code, validating a Gradle wrapper, setting up Java, building, and uploading artifacts) do not require any write access to the repository contents, the best minimal permission is `contents: read`. This change should be made in `.github/workflows/build.yml` by inserting the permissions block after the `name` and `on` keys, and before `jobs:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
